### PR TITLE
feat: update naver map open api url

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 ### 0.
 
 시작에 앞서 어플리케이션 등록이 필요합니다. 이미 `클라이언트 아이디`가 있다면 이 부분은 넘어가셔도 됩니다.
-2018년 11월 13일 부로 네이버 신규 어플리케이션 등록은 [네이버 클라우드 플랫폼](https://www.ncloud.com/)에서 가능합니다. 자세한 내용은 [네이버 클라우드 플랫폼 Maps API](https://navermaps.github.io/maps.js.ncp/index.html)를 참고하세요. 기존 [네이버 개발자 센터](https://developers.naver.com/) 클라이언트 아이디는 2019년 4월 19일 까지 사용가능합니다.
+2018년 11월 13일 부로 네이버 신규 어플리케이션 등록은 [네이버 클라우드 플랫폼](https://www.ncloud.com/)에서 가능합니다. 자세한 내용은 [네이버 클라우드 플랫폼 Maps API](https://navermaps.github.io/maps.js.ncp/index.html)를 참고하세요. **기존 [네이버 개발자 센터](https://developers.naver.com/) 클라이언트 아이디는 2019년 4월 19일 까지 사용가능합니다.**
 
 - [Naver Maps Enterprise API 공지사항](https://developers.naver.com/notice/article/10000000000030663434)
 - [Naver Cloud Platform 클라이언트 아이디 발급](https://navermaps.github.io/maps.js.ncp/tutorial-1-Getting-Client-ID.html)
@@ -15,7 +15,7 @@ React Naver Maps를 사용하기전 먼저 Naver Maps 스크립트를 불러와�
 ...
 <script 
   type="text/javascript" 
-  src="https://openapi.map.naver.com/openapi/v3/maps.js?clientId=YOUR_CLIENT_ID">
+  src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=YOUR_CLIENT_ID">
 </script>
 <script ...>
 ```

--- a/examples/script-tag/public/template.html
+++ b/examples/script-tag/public/template.html
@@ -9,7 +9,7 @@
 <body>
   <div id="root"></div>
   <!-- bundle 이 추가되기전 naver map을 불러온다. -->
-  <script src="https://openapi.map.naver.com/openapi/v3/maps.js?clientId=<%= htmlWebpackPlugin.options.naverMapsClientId %>"></script>  
+  <script src="https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=<%= htmlWebpackPlugin.options.naverMapsClientId %>"></script>  
 
   <!-- webpack bundle이 inject되는 자리  -->
 </body>

--- a/src/loadNavermapsScript.js
+++ b/src/loadNavermapsScript.js
@@ -6,12 +6,7 @@ const _loadNavermapsScript = ({ clientId, submodules, ncpClientId }) => {
 
   // build naver maps v3 api url
   let requestUrl = `https://openapi.map.naver.com/openapi/v3/maps.js`;
-
-  if (clientId) {
-    requestUrl += `?clientId=${clientId}`;
-  } else if (ncpClientId) {
-    requestUrl += `?ncpClientId=${ncpClientId}`;
-  }
+  requestUrl += `?ncpClientId=${clientId || ncpClientId}`;
 
   if (submodules) {
     requestUrl += `&submodules=${submodules.join(',')}`;


### PR DESCRIPTION
**Why?**
기존 [네이버 개발자 센터](https://developers.naver.com/) 클라이언트 아이디는 **2019년 4월 19일** 까지 사용가능하여 종료 되었고 `https://openapi.map.naver.com/openapi/v3/maps.js?clientId` 형태로 사용되고 있는 부분이 필요 없어졌으므로 `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId` 와 같은 꼴로 수정되어야 합니다.

![스크린샷 2019-06-22 오전 3 21 21](https://user-images.githubusercontent.com/26598542/59944399-a7f3e280-949f-11e9-93cb-ad37994fb43c.png)

**Changes**

- `src/loadNavermapsScript.js` 경로에 있던 clientId, ncpClientId로 url 분기를 치던 부분을 ncpClientId로 url이 일괄 적용 되도록 기존 clientId ncpClientId 를 사용하는 사람들이 모두 사용할수 있도록 수정하였습니다.
- 예제 map api주소를 변경했습니다.

**Post actions**
- 예제에 있는 client id가 ncp에서 발급받은 client id 로 교체되어야 합니다.
- setUp.js에 있는 아래 부분
```javascript
const MAP_CLIENT_ID = process.env.MAP_CLIENT_ID || 'lvSuBZ0VzLiv7k7YbJXt'
```
본인의 ncp client id로 넣어 테스트한 결과 현재 예제 페이지에 나오고 있지않는 map들 정상 작동
![스크린샷 2019-06-22 오전 3 54 48](https://user-images.githubusercontent.com/26598542/59945137-9a3f5c80-94a1-11e9-82ab-6da68879d023.png)
