### PR TITLE
fix: react-naver-map 에 기재된 다른 provider 명 변경

### DIFF
--- a/packages/react-naver-maps/src/index.ts
+++ b/packages/react-naver-maps/src/index.ts
@@ -1,6 +1,6 @@
 
 
-export { NavermapsProvider } from './provider';
+export { NavermMpsProvider } from './provider';
 export { NaverMap } from './naver-map';
 export { Container } from './container';
 export { Circle } from './overlays/circle';

--- a/packages/react-naver-maps/src/index.ts
+++ b/packages/react-naver-maps/src/index.ts
@@ -1,6 +1,6 @@
 
 
-export { NavermapsProvider } from './provider';
+export { NaverMapsProvider } from './provider';
 export { NaverMap } from './naver-map';
 export { Container } from './container';
 export { Circle } from './overlays/circle';

--- a/packages/react-naver-maps/src/index.ts
+++ b/packages/react-naver-maps/src/index.ts
@@ -1,6 +1,6 @@
 
 
-export { NavermMpsProvider } from './provider';
+export { NavermapsProvider } from './provider';
 export { NaverMap } from './naver-map';
 export { Container } from './container';
 export { Circle } from './overlays/circle';

--- a/packages/react-naver-maps/src/provider.tsx
+++ b/packages/react-naver-maps/src/provider.tsx
@@ -5,7 +5,7 @@ import type { ClientOptions } from './types/client';
 
 export type Props = ClientOptions & { children?: ReactNode };
 
-export function NavermapsProvider({
+export function NaverMapsProvider({
   children,
   ...clientOptions
 }: Props) {

--- a/website/src/menu.ts
+++ b/website/src/menu.ts
@@ -77,7 +77,7 @@ export const menu = [
     name: 'API Reference',
     contents: [
       {
-        name: 'NavermapsProvider',
+        name: 'NaverMapsProvider',
         href: '/api-references/navermaps-provider',
       },
       {

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/router';
 import Script from 'next/script';
 import { ComponentPropsWithoutRef, useEffect } from 'react';
 import { FiExternalLink } from 'react-icons/fi';
-import { NavermapsProvider } from 'react-naver-maps';
+import { NaverMapsProvider } from 'react-naver-maps';
 import { Prism } from 'react-syntax-highlighter';
 import { materialLight } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 
@@ -141,13 +141,13 @@ function App({ Component, pageProps }: AppProps) {
         },
         'a:visited': { color: 'inherit' },
       })}/>
-      <NavermapsProvider ncpClientId='6tdrlcyvpt'>
+      <NaverMapsProvider ncpClientId='6tdrlcyvpt'>
         <MDXProvider components={mdxComponents}>
           <Layout>
             <Component {...pageProps} />
           </Layout>
         </MDXProvider>
-      </NavermapsProvider>
+      </NaverMapsProvider>
     </>
   );
 }

--- a/website/src/pages/api-references/navermaps-provider.mdx
+++ b/website/src/pages/api-references/navermaps-provider.mdx
@@ -1,21 +1,21 @@
 import { Props } from 'next-docz';
-import { NavermapsProvider } from 'react-naver-maps'
+import { NaverMapsProvider } from 'react-naver-maps'
 
-# NavermapsProvider
+# NaverMapsProvider
 
 [네이버 공식 문서 서브 모듈 시스템](https://navermaps.github.io/maps.js.ncp/docs/tutorial-4-Submodules.html)
 
 ## Props
 
-<Props of={NavermapsProvider} />
+<Props of={NaverMapsProvider} />
 
 ## Example
 
 ``` jsx
-<NavermapsProvider 
+<NaverMapsProvider
   ncpClientId='YOUR_CLIENT_ID'
   submodules={['panorama']}
 >
   <YourApp />
-</NavermapsProvider>
+</NaverMapsProvider>
 ```

--- a/website/src/pages/guides/migration-guide-from-0.0.mdx
+++ b/website/src/pages/guides/migration-guide-from-0.0.mdx
@@ -3,7 +3,7 @@
 ## Removed `<RenderAfterNavermapsLoaded />`
 
 기존 RenderAfterNavermapsLoaded 는 SSR 문제와 컴포넌트 렌더 시의 모호함이 있었고 v0.1 에서 제거되었습니다. 
-대신, Application Root 에 `<NavermapsProvider />`를 추가해주세요
+대신, Application Root 에 `<NaverMapsProvider />`를 추가해주세요
 
 ``` jsx
 // v0.0 (X)
@@ -16,13 +16,13 @@ import { RenderAfterNavermapsLoaded } from 'react-naver-maps'
 </RenderAfterNavermapsLoaded>
 
 // v0.1 (O)
-import { NavermapsProvider } from 'react-naver-maps'
+import { NaverMapsProvider } from 'react-naver-maps'
 
-<NavermapsProvider
+<NaverMapsProvider
   ncpClientId={YOUR_CLIENT_ID}
 >
   <TheRestOfYourApplication />
-</NavermapsProvider>
+</NaverMapsProvider>
 ```
 
 ## Add `<Container />`
@@ -130,14 +130,14 @@ function Call() {
 ``` jsx
 // v0.1 (O)
 import { Suspense } from 'react'
-import { Container as MapDiv, NaverMap, useNavermaps, NavermapsProvider } from 'react-naver-maps'
+import { Container as MapDiv, NaverMap, useNavermaps, NaverMapsProvider } from 'react-naver-maps'
 
 // Your App Root
 function App() {
   return (
-    <NavermapsProvider ncpClientId={MY_CLIENTID}>
+    <NaverMapsProvider ncpClientId={MY_CLIENTID}>
       <MyMap />
-    </NavermapsProvider>
+    </NaverMapsProvider>
   )
 }
 


### PR DESCRIPTION
<img width="1146" alt="스크린샷 2023-07-13 오전 11 44 00" src="https://github.com/zeakd/react-naver-maps/assets/67212771/9846a3fe-bce2-4912-8f09-430805c7f578">

<img width="719" alt="스크린샷 2023-07-13 오전 11 44 22" src="https://github.com/zeakd/react-naver-maps/assets/67212771/509b5574-8901-422a-ac1a-2b9810d0b036">
