### PR TITLE
fix(load-script): submodule 로드 완료 대기 + URL 쉼표 인코딩 수정

### DIFF
--- a/packages/react-naver-maps/src/__tests__/load-script.spec.ts
+++ b/packages/react-naver-maps/src/__tests__/load-script.spec.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from 'vitest';
-import { getClientParam } from '../load-script.js';
+import {
+  buildUrl,
+  getClientParam,
+  waitForJsContentLoaded,
+} from '../load-script.js';
 
 describe('getClientParam', () => {
   test('ncpKeyId 전달 시 ["ncpKeyId", value] 반환', () => {
@@ -32,5 +36,88 @@ describe('getClientParam', () => {
 
   test('키 없으면 에러', () => {
     expect(() => getClientParam({} as any)).toThrow('인증 키가 필요합니다');
+  });
+});
+
+describe('buildUrl', () => {
+  test('submodules 전달 시 raw `,` 가 URL 에 보존됨 (URL-encoded `%2C` 아님)', () => {
+    const url = buildUrl({
+      ncpKeyId: 'test-key',
+      submodules: ['geocoder', 'drawing'],
+    });
+    expect(url).toContain('submodules=geocoder,drawing');
+    expect(url).not.toContain('%2C');
+  });
+
+  test('submodules 미전달 시 submodules 쿼리 자체가 추가되지 않음', () => {
+    const url = buildUrl({ ncpKeyId: 'test-key' });
+    expect(url).not.toContain('submodules');
+  });
+
+  test('인증 키 파라미터는 URLSearchParams 통과 (특수문자 안전)', () => {
+    const url = buildUrl({ ncpKeyId: 'a b+c' });
+    expect(url).toContain('ncpKeyId=a+b%2Bc');
+  });
+});
+
+describe('waitForJsContentLoaded', () => {
+  test('jsContentLoaded=true 이면 즉시 resolve', async () => {
+    const maps = { jsContentLoaded: true } as unknown as typeof naver.maps;
+    await expect(waitForJsContentLoaded(maps)).resolves.toBe(maps);
+  });
+
+  test('jsContentLoaded=false 면 onJSContentLoaded 콜백 발화까지 대기', async () => {
+    const maps = {
+      jsContentLoaded: false,
+      onJSContentLoaded: undefined as undefined | (() => void),
+    } as unknown as typeof naver.maps & {
+      onJSContentLoaded: undefined | (() => void);
+    };
+
+    const promise = waitForJsContentLoaded(maps);
+
+    let resolved = false;
+    promise.then(() => {
+      resolved = true;
+    });
+
+    // 콜백 발화 전: promise 가 아직 pending 이어야 함
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    // 콜백 발화
+    maps.onJSContentLoaded?.();
+    await expect(promise).resolves.toBe(maps);
+  });
+
+  test('기존 onJSContentLoaded 핸들러가 있으면 chain 보호 (prev 호출 후 resolve)', async () => {
+    let prevCalled = false;
+    const maps = {
+      jsContentLoaded: false,
+      onJSContentLoaded: () => {
+        prevCalled = true;
+      },
+    } as unknown as typeof naver.maps;
+
+    const promise = waitForJsContentLoaded(maps);
+
+    // 우리가 새로 등록한 콜백 발화
+    (maps as any).onJSContentLoaded();
+    await promise;
+
+    expect(prevCalled).toBe(true);
+  });
+
+  test('기존 onJSContentLoaded 핸들러가 throw 해도 우리 resolve 는 진행됨', async () => {
+    const maps = {
+      jsContentLoaded: false,
+      onJSContentLoaded: () => {
+        throw new Error('prev throws');
+      },
+    } as unknown as typeof naver.maps;
+
+    const promise = waitForJsContentLoaded(maps);
+    (maps as any).onJSContentLoaded();
+    await expect(promise).resolves.toBe(maps);
   });
 });

--- a/packages/react-naver-maps/src/__tests__/load-script.spec.ts
+++ b/packages/react-naver-maps/src/__tests__/load-script.spec.ts
@@ -101,14 +101,14 @@ describe('waitForJsContentLoaded', () => {
 
     const promise = waitForJsContentLoaded(maps);
 
-    // 우리가 새로 등록한 콜백 발화
+    // waitForJsContentLoaded 가 새로 등록한 콜백 발화
     (maps as any).onJSContentLoaded();
     await promise;
 
     expect(prevCalled).toBe(true);
   });
 
-  test('기존 onJSContentLoaded 핸들러가 throw 해도 우리 resolve 는 진행됨', async () => {
+  test('기존 onJSContentLoaded 핸들러가 throw 해도 waitForJsContentLoaded 의 Promise resolve 는 진행됨', async () => {
     const maps = {
       jsContentLoaded: false,
       onJSContentLoaded: () => {

--- a/packages/react-naver-maps/src/load-script.ts
+++ b/packages/react-naver-maps/src/load-script.ts
@@ -57,16 +57,40 @@ export function getClientParam(options: LoadOptions): [string, string] {
 function buildUrl(options: LoadOptions): string {
   const [paramName, paramValue] = getClientParam(options);
   const params = new URLSearchParams({ [paramName]: paramValue });
+  let url = `https://oapi.map.naver.com/openapi/v3/maps.js?${params.toString()}`;
   if (options.submodules?.length) {
-    params.set('submodules', options.submodules.join(','));
+    // Naver Maps 로더는 submodules 쿼리 값을 raw `,` 로 split 해서
+    // 각 `maps-{name}.js` 청크를 로드합니다. URLSearchParams 가 `,` 를
+    // `%2C` 로 percent-encode 하면 로더가 전체 문자열을 하나의 submodule
+    // 이름으로 취급해 `maps-{joined}%2C{...}.js` 에 요청 → 404 발생.
+    url += `&submodules=${options.submodules.join(',')}`;
   }
-  return `https://oapi.map.naver.com/openapi/v3/maps.js?${params.toString()}`;
+  return url;
 }
 
 function cacheKey(options: LoadOptions): string {
   const [, paramValue] = getClientParam(options);
   const sub = options.submodules?.toSorted().join(',') ?? '';
   return `${paramValue}:${sub}`;
+}
+
+function waitForJsContentLoaded(
+  maps: typeof naver.maps,
+): Promise<typeof naver.maps> {
+  if (maps.jsContentLoaded) return Promise.resolve(maps);
+  return new Promise((resolve) => {
+    const prev = maps.onJSContentLoaded;
+    maps.onJSContentLoaded = () => {
+      if (typeof prev === 'function') {
+        try {
+          prev();
+        } catch {
+          // chained handler 의 에러가 submodule resolution 을 막지 않도록 swallow
+        }
+      }
+      resolve(maps);
+    };
+  });
 }
 
 export function loadScript(options: LoadOptions): Promise<typeof naver.maps> {
@@ -80,7 +104,7 @@ export function loadScript(options: LoadOptions): Promise<typeof naver.maps> {
 
   const promise = new Promise<typeof naver.maps>((resolve, reject) => {
     if (typeof naver !== 'undefined' && naver.maps) {
-      resolve(naver.maps);
+      waitForJsContentLoaded(naver.maps).then(resolve);
       return;
     }
 
@@ -89,7 +113,7 @@ export function loadScript(options: LoadOptions): Promise<typeof naver.maps> {
     script.async = true;
     script.addEventListener('load', () => {
       if (typeof naver !== 'undefined' && naver.maps) {
-        resolve(naver.maps);
+        waitForJsContentLoaded(naver.maps).then(resolve);
       } else {
         reject(new Error('naver.maps not available after script load'));
       }

--- a/packages/react-naver-maps/src/load-script.ts
+++ b/packages/react-naver-maps/src/load-script.ts
@@ -54,7 +54,8 @@ export function getClientParam(options: LoadOptions): [string, string] {
   );
 }
 
-function buildUrl(options: LoadOptions): string {
+/** @internal exported for tests */
+export function buildUrl(options: LoadOptions): string {
   const [paramName, paramValue] = getClientParam(options);
   const params = new URLSearchParams({ [paramName]: paramValue });
   let url = `https://oapi.map.naver.com/openapi/v3/maps.js?${params.toString()}`;
@@ -74,7 +75,8 @@ function cacheKey(options: LoadOptions): string {
   return `${paramValue}:${sub}`;
 }
 
-function waitForJsContentLoaded(
+/** @internal exported for tests */
+export function waitForJsContentLoaded(
   maps: typeof naver.maps,
 ): Promise<typeof naver.maps> {
   if (maps.jsContentLoaded) return Promise.resolve(maps);


### PR DESCRIPTION
## 요약

`react-naver-maps@0.2.0` 의 `src/load-script.ts` 에 있는 두 회귀를 한 번에 수정합니다. 두 회귀 모두 `submodules` 옵션을 무력화해서 submodule 네임스페이스(예: geocoder 의 `naver.maps.Service`) 가 런타임에 웹에 붙지 않았습니다.

비교 기준 버전: [`0.1.5`](https://github.com/zeakd/react-naver-maps/releases/tag/react-naver-maps%400.1.5) — 직전 안정 릴리즈로, 같은 시나리오에서 정상 동작을 확인했습니다.

## 재현

Next.js 15+ / React 19 환경의 이런 컴포넌트가 있다면:


```tsx
'use client';
import { NavermapsProvider, useNavermaps } from 'react-naver-maps';

function Inner() {
  const navermaps = useNavermaps();
  console.log('Service:', navermaps.Service);   // undefined 
  return null;
}

export default function Page() {
  return (
    <NavermapsProvider
      ncpKeyId="<key>"
      submodules={['geocoder', 'drawing']}
    >
      <Inner />
    </NavermapsProvider>
  );
}
```



이후 click handler 등에서 `navermaps.Service.reverseGeocode(...)` 를 호출하면:

```
TypeError: Cannot read properties of undefined (reading 'reverseGeocode')
```



Network 탭에서는 다음 404 도 함께 잡힙니다:

```
GET https://oapi.map.naver.com/openapi/v3/maps-geocoder%2Cdrawing.js → 404
```



<img width="652" height="253" alt="스크린샷 2026-05-11 오후 4 55 44" src="https://github.com/user-attachments/assets/0000af22-e83a-461a-9522-55e8ad9c14ba" />


<img width="324" height="180" alt="스크린샷 2026-05-11 오후 4 31 37" src="https://github.com/user-attachments/assets/45dbbaf7-1acb-43cc-a67c-ac524d1ec314" />


## 원인 (1) — `buildUrl` 이 submodules 쿼리의 쉼표를 `%2C` 로 percent-encode


```ts
// src/load-script.ts (현재 0.2.0)
function buildUrl(options: LoadOptions): string {
  const [paramName, paramValue] = getClientParam(options);
  const params = new URLSearchParams({ [paramName]: paramValue });
  if (options.submodules?.length) {
    params.set('submodules', options.submodules.join(','));   // ← URLSearchParams가 `,`를 `%2C`로 인코딩
  }
  return `https://oapi.map.naver.com/openapi/v3/maps.js?${params.toString()}`;
}
```



Naver Maps 메인 `maps.js` 는 자기 `script.src` 의 `submodules` 쿼리 값을 raw `,` 로 split 한 다음 각 청크를 `maps-{name}.js` 로 로드합니다. `geocoder%2Cdrawing` (URL-encoded) 이 들어오면 전체 문자열을 submodule 이름 하나로 취급해서 `https://oapi.map.naver.com/openapi/v3/maps-geocoder%2Cdrawing.js` 를 요청하고 404 가 떨어집니다. geocoder/drawing 양쪽 다 attach 실패.

0.1.x 는 템플릿 문자열로 URL 을 만들어서 raw 쉼표가 그대로 살아 있었습니다:


```ts
// 0.1.5 — packages/react-naver-maps/src/load-navermaps-script.tsx
let url = `https://oapi.map.naver.com/openapi/v3/maps.js?${clientIdQuery}`;

if (submodules) {
  url += `&submodules=${submodules.join(',')}`;
}

return url;
```



## 원인 (2) — `loadScript` 가 submodule attach 전에 resolve


```ts
// src/load-script.ts (현재 0.2.0)
script.addEventListener('load', () => {
  if (typeof naver !== 'undefined' && naver.maps) {
    resolve(naver.maps);   // ← submodule 아직 미부착 상태
  } else {
    reject(new Error('naver.maps not available after script load'));
  }
});
```



Naver Maps JS API 는 메인 script 의 `load` 이벤트 이후에 submodule 을 비동기로 로드합니다:

1. 메인 `maps.js?…&submodules=geocoder,drawing` script tag 의 `load` 이벤트 발화
2. `naver`, `naver.maps` 코어 네임스페이스가 사용 가능해짐
3. 메인 script 가 submodule 마다 `<script>` 태그를 추가로 동적 삽입
4. 모든 submodule 로드 완료 → `naver.maps.jsContentLoaded = true` + `naver.maps.onJSContentLoaded()` 발화

0.1.x 는 이 신호를 정확히 기다렸습니다:


```ts
// 0.1.5 — packages/react-naver-maps/src/load-navermaps-script.tsx (관련 부분 발췌)
const promise = loadScript(url).then(() => {
  const navermaps = window.naver?.maps;
  if (!navermaps) throw new Error('...'); // 에러 메시지 생략

  if (navermaps.jsContentLoaded) {
    return navermaps;
  }

  return new Promise<typeof naver.maps>(resolve => {
    navermaps.onJSContentLoaded = () => {
      resolve(navermaps);
    };
  });
});
```


`grep -rn "onJSContentLoaded\|jsContentLoaded" src/` 결과 0.2.0 에서 0건 — 재작성 과정에서 누락된 것으로 보입니다.

## 0.1.5 정상 동작 비교

같은 시나리오를 v0.1.5 website 에 페이지를 추가해 돌려본 결과:

<img width="366" height="198" alt="스크린샷 2026-05-11 오후 4 50 38" src="https://github.com/user-attachments/assets/0180e05f-73f7-4f77-9ee7-d053884c85af" />

> 참고: 0.1.5 console.log 테스트에서는 `navermaps.drawing` (소문자) 으로 접근했습니다. Naver Maps API 가 drawing submodule 을 소문자 네임스페이스로 노출하기 때문인것으로 보입니다 (`Service` 는 대문자, `drawing` / `visualization` 은 소문자 — 이 PR 의 fix 와는 무관한 API 컨벤션).

## 변경 사항

### 1. `buildUrl` — submodules 쿼리의 raw 쉼표 보존

`URLSearchParams` 가 `,` 를 `%2C` 로 인코딩하면 Naver Maps 의 submodule chunk 로더가 `maps-geocoder%2Cdrawing.js` 같은 잘못된 URL 을 요청해서 404 가 납니다. 인증 키 파라미터는 안전하게 `URLSearchParams` 로 유지하고, submodules 만 raw 쉼표로 append 합니다.

### 2. `loadScript` — `onJSContentLoaded` 대기

Naver Maps script 의 `load` 이벤트는 코어만 부착된 시점이고, submodule 은 그 뒤에 비동기로 로드됩니다. `naver.maps.onJSContentLoaded` 콜백이 모든 submodule 로드 완료 신호입니다. 0.1.5 에 있던 이 대기 로직을 복원했습니다. `prev` 핸들러 chain 을 보호하기 위해, 기존 onJSContentLoaded 가 있으면 호출하고 나서 waitForJsContentLoaded 가 등록하는 새 핸들러로 교체합니다.

`submodules` 가 비어 있으면 `jsContentLoaded` 가 메인 script `load` 와 같은 tick 에 true 가 되므로, 추가한 대기 로직은 곧바로 통과합니다 → submodule 미사용 호출자 동작은 그대로입니다.

## 회귀 방지 테스트 (이 PR 에 포함)

`packages/react-naver-maps/src/__tests__/load-script.spec.ts` 에 두 helper 를 직접 검증하는 테스트 7개를 추가했습니다. `buildUrl` / `waitForJsContentLoaded` 는 테스트 접근을 위해 `/** @internal exported for tests */` 주석과 함께 export 했습니다 (외부 사용 의도는 아닙니다).

#### buildUrl (3개)
- submodules 전달 시 raw `,` 가 URL 에 보존 (URL-encoded `%2C` 아님) — URL 인코딩 회귀를 직접 막음
- submodules 미전달 시 submodules 쿼리 자체가 붙지 않음
- 인증 키 파라미터는 URLSearchParams 통과 (특수문자 안전)

#### waitForJsContentLoaded (4개)
- `jsContentLoaded=true` 면 즉시 resolve
- `jsContentLoaded=false` 면 `onJSContentLoaded` 콜백 발화까지 대기 — submodule attach 대기 회귀를 직접 막음
- 기존 `onJSContentLoaded` 핸들러 chain 보호 (prev 호출 후 resolve)
- 기존 핸들러가 throw 해도  waitForJsContentLoaded 의 Promise는 resolve


전체 결과: 22 files / 128 tests pass (기존 121개 + 신규 7개).

## 검증

저희 프로젝트(Next.js 16 + React 19) 에 `pnpm patch` 로 같은 변경을 적용한 뒤:

- Network 탭: `maps-geocoder.js`, `maps-drawing.js` 가 각각 200 OK 로 따로 로드됨 ✅ (이전엔 `maps-geocoder%2Cdrawing.js` 단일 404)
- `useNavermaps()` 가 submodule attach 된 `naver.maps` 로 resolve ✅
- `navermaps.Service.reverseGeocode(...)` 가 첫 호출부터 정상 동작 ✅
- submodules 미사용 호출자 동작 변화 없음 ✅

> 추가로 패치한 빌드를 저희 프로덕션에 배포해서 핵심 시나리오(주소 검색 → reverseGeocode, 지도 클릭 → 마커 생성 모드) 가 정상 동작하는지 확인했습니다. 다만 `panorama` / `visualization` 처럼 저희가 쓰지 않는 submodule 시나리오는 검증하지 못했습니다.

## 로컬 환경 빌드/테스트

- `tsc -b`: 통과 ✅
- `oxlint`: 0 warnings, 0 errors ✅
- `oxfmt --check`: 모두 정상 ✅
- `vitest run` (chromium browser mode): 22 files / 128 tests 모두 pass ✅

Closes #158