### PR TITLE
chore: changeset + loadScript 통합 테스트 (#159 후속)

### DIFF
--- a/.changeset/fix-load-script-submodules.md
+++ b/.changeset/fix-load-script-submodules.md
@@ -2,11 +2,11 @@
 "react-naver-maps": patch
 ---
 
-fix(load-script): submodules 로드 회귀 수정
+fix(load-script): submodules 로드 회귀 수정 (#159)
 
-0.2.0(v2 재작성)에서 `submodules` 옵션이 무력화되어 geocoder의 `naver.maps.Service` 등 submodule 네임스페이스가 런타임에 attach되지 않던 두 회귀를 수정한다.
+0.2.0에서 `submodules` 옵션이 무력화되던 두 회귀를 수정한다.
 
-- `buildUrl`: `URLSearchParams`가 submodules 쿼리의 `,`를 `%2C`로 percent-encode → naver 로더가 `maps-geocoder%2Cdrawing.js` 단일 청크를 요청해 404. 인증 키만 `URLSearchParams`로 유지하고 submodules는 raw 쉼표로 append (0.1.x 동작 복원).
-- `loadScript`: 메인 script `load` 이벤트는 코어만 attach된 시점이고 submodule은 그 뒤 비동기로 로드된다. `naver.maps.onJSContentLoaded` 대기 로직을 복원해 모든 submodule attach 완료 후 resolve하도록 수정. submodules 미사용 호출자는 `jsContentLoaded`가 같은 tick에 true가 되어 동작 변화 없음.
+- URL의 쉼표가 `%2C`로 인코딩되어 submodule 청크가 404나던 문제 → raw 쉼표 복원
+- submodule attach(`onJSContentLoaded`) 전에 resolve하던 문제 → attach 완료까지 대기
 
 Closes #158

--- a/.changeset/fix-load-script-submodules.md
+++ b/.changeset/fix-load-script-submodules.md
@@ -1,0 +1,12 @@
+---
+"react-naver-maps": patch
+---
+
+fix(load-script): submodules 로드 회귀 수정
+
+0.2.0(v2 재작성)에서 `submodules` 옵션이 무력화되어 geocoder의 `naver.maps.Service` 등 submodule 네임스페이스가 런타임에 attach되지 않던 두 회귀를 수정한다.
+
+- `buildUrl`: `URLSearchParams`가 submodules 쿼리의 `,`를 `%2C`로 percent-encode → naver 로더가 `maps-geocoder%2Cdrawing.js` 단일 청크를 요청해 404. 인증 키만 `URLSearchParams`로 유지하고 submodules는 raw 쉼표로 append (0.1.x 동작 복원).
+- `loadScript`: 메인 script `load` 이벤트는 코어만 attach된 시점이고 submodule은 그 뒤 비동기로 로드된다. `naver.maps.onJSContentLoaded` 대기 로직을 복원해 모든 submodule attach 완료 후 resolve하도록 수정. submodules 미사용 호출자는 `jsContentLoaded`가 같은 tick에 true가 되어 동작 변화 없음.
+
+Closes #158

--- a/packages/react-naver-maps/src/__tests__/load-script.spec.ts
+++ b/packages/react-naver-maps/src/__tests__/load-script.spec.ts
@@ -1,7 +1,8 @@
-import { describe, test, expect } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import {
   buildUrl,
   getClientParam,
+  loadScript,
   waitForJsContentLoaded,
 } from '../load-script.js';
 
@@ -119,5 +120,58 @@ describe('waitForJsContentLoaded', () => {
     const promise = waitForJsContentLoaded(maps);
     (maps as any).onJSContentLoaded();
     await expect(promise).resolves.toBe(maps);
+  });
+});
+
+// loadScript 진입점부터의 통합 경로. 단위 테스트(waitForJsContentLoaded)와 달리
+// loadScript 가 실제로 submodule attach 를 기다리도록 와이어링됐는지 검증한다.
+// 이미 naver.maps 가 로드된 경로만 다룬다(script 태그 append/네트워크 경로는 E2E 영역).
+describe('loadScript (통합)', () => {
+  const original = (globalThis as any).naver;
+  afterEach(() => {
+    (globalThis as any).naver = original;
+  });
+
+  test('이미 로드됨 + jsContentLoaded=true 면 즉시 resolve', async () => {
+    const maps = { jsContentLoaded: true } as unknown as typeof naver.maps;
+    (globalThis as any).naver = { maps };
+    // cache 격리를 위해 테스트마다 고유 키 사용
+    await expect(
+      loadScript({ ncpKeyId: 'loadScript-loaded-true' }),
+    ).resolves.toBe(maps);
+  });
+
+  test('이미 로드됨 + jsContentLoaded=false 면 onJSContentLoaded 발화까지 대기 후 resolve', async () => {
+    const maps = {
+      jsContentLoaded: false,
+      onJSContentLoaded: undefined as undefined | (() => void),
+    } as unknown as typeof naver.maps & {
+      onJSContentLoaded: undefined | (() => void);
+    };
+    (globalThis as any).naver = { maps };
+
+    let resolved = false;
+    const promise = loadScript({ ncpKeyId: 'loadScript-loaded-false' }).then(
+      (r) => {
+        resolved = true;
+        return r;
+      },
+    );
+
+    await Promise.resolve();
+    // 회귀(직접 resolve)였다면 여기서 이미 resolved=true 였을 것
+    expect(resolved).toBe(false);
+
+    maps.onJSContentLoaded!(); // submodule attach 완료 신호
+    await expect(promise).resolves.toBe(maps);
+    expect(resolved).toBe(true);
+  });
+
+  test('같은 options 재호출 시 동일 Promise 반환 (cache)', () => {
+    const maps = { jsContentLoaded: true } as unknown as typeof naver.maps;
+    (globalThis as any).naver = { maps };
+    const a = loadScript({ ncpKeyId: 'loadScript-cache' });
+    const b = loadScript({ ncpKeyId: 'loadScript-cache' });
+    expect(a).toBe(b);
   });
 });


### PR DESCRIPTION
#159(submodules 로드 회귀 수정)가 changeset 없이 머지되어, 후속으로 정리합니다.

## 포함 내용

- **patch changeset** — `react-naver-maps` 0.2.0 → 0.2.1, CHANGELOG에 회귀 수정 기록
- **loadScript 통합 테스트 3개** — #159의 단위 테스트(buildUrl/waitForJsContentLoaded)가 못 덮던 `loadScript` 진입점 경로 검증: 이미-로드 / onJSContentLoaded 대기 / cache. **12 → 15 tests.**

## 검증

tsc -b / oxlint / oxfmt / vitest(load-script 15 tests) 통과.